### PR TITLE
tasks controllerのバグを修正

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i(show edit update destroy)
-  before_action :set_labels, only: %i(index new edit)
+  before_action :set_labels, only: %i(index new edit create)
   before_action :require_login
 
   def index


### PR DESCRIPTION
タスク作成時のバリデーションで弾かれた場合にTemplate::Errorが出てしまうバグを修正しました。